### PR TITLE
Print help message for Command parse errors

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -223,7 +223,8 @@ pub(crate) fn run(args: Vec<String>) -> Result<(), Error> {
         }
         Ok(args) => args,
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("error: {}\n", e);
+            Args::print_usage();
             exit(2);
         }
     };


### PR DESCRIPTION
Prints the nice help message if command parsing fails.

Before:
```
$ cargo proc-macro hi
unrecognized command `hi`
```

After:
```
$ cargo proc-macro hi
error: unrecognized command `hi`

cargo-proc-macro -- Manage proc-macro crates with Cargo
<https://github.com/bbqsrc/cargo-proc-macro>

Usage: cargo proc-macro [OPTIONS] [SUBCOMMAND]

Optional arguments:
  -h, --help  show help information

Available commands:
  new   Create a new set of proc-macro crates at given path
  init  Create a new set of proc-macro crates in an existing directory
```